### PR TITLE
tclSE-back-port: timerate and more

### DIFF
--- a/generic/tclBasic.c
+++ b/generic/tclBasic.c
@@ -286,7 +286,7 @@ static const CmdInfo builtInCmds[] = {
     {"source",		Tcl_SourceObjCmd,	NULL,			TclNRSourceObjCmd,	0},
     {"tell",		Tcl_TellObjCmd,		NULL,			NULL,	CMD_IS_SAFE},
     {"time",		Tcl_TimeObjCmd,		NULL,			NULL,	CMD_IS_SAFE},
-    {"timerate",    Tcl_TimeRateObjCmd, NULL,           NULL,   CMD_IS_SAFE},
+    {"timerate",	Tcl_TimeRateObjCmd,	NULL,			NULL,	CMD_IS_SAFE},
     {"unload",		Tcl_UnloadObjCmd,	NULL,			NULL,	0},
     {"update",		Tcl_UpdateObjCmd,	NULL,			NULL,	CMD_IS_SAFE},
     {"vwait",		Tcl_VwaitObjCmd,	NULL,			NULL,	CMD_IS_SAFE},

--- a/generic/tclBasic.c
+++ b/generic/tclBasic.c
@@ -286,6 +286,7 @@ static const CmdInfo builtInCmds[] = {
     {"source",		Tcl_SourceObjCmd,	NULL,			TclNRSourceObjCmd,	0},
     {"tell",		Tcl_TellObjCmd,		NULL,			NULL,	CMD_IS_SAFE},
     {"time",		Tcl_TimeObjCmd,		NULL,			NULL,	CMD_IS_SAFE},
+    {"timerate",    Tcl_TimeRateObjCmd, NULL,           NULL,   CMD_IS_SAFE},
     {"unload",		Tcl_UnloadObjCmd,	NULL,			NULL,	0},
     {"update",		Tcl_UpdateObjCmd,	NULL,			NULL,	CMD_IS_SAFE},
     {"vwait",		Tcl_VwaitObjCmd,	NULL,			NULL,	CMD_IS_SAFE},

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4211,6 +4211,7 @@ usage:
 	    return TCL_ERROR;
 	}
 	codePtr = TclCompileObj(interp, objPtr, NULL, 0);
+	TclPreserveByteCode(codePtr);
     }
 
     /* get start and stop time */
@@ -4238,7 +4239,7 @@ usage:
 	    result = TclEvalObjEx(interp, objPtr, 0, NULL, 0);
 	}
 	if (result != TCL_OK) {
-	    return result;
+	    goto done;
 	}
 	
 	/* don't check time up to threshold */
@@ -4333,6 +4334,12 @@ usage:
 	TclNewLiteralStringObj(objs[3], "#,");
 	TclNewLiteralStringObj(objs[5], "#/sec");
 	Tcl_SetObjResult(interp, Tcl_NewListObj((!calibrate) ? 6 : 8, objarr));
+    }
+
+done:
+
+    if (codePtr != NULL) {
+	TclReleaseByteCode(codePtr);
     }
 
     return result;

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4278,6 +4278,7 @@ usage:
 	if (!calibrate) {
 	    /* minimize influence of measurement overhead */
 	    if (overhead > 0) {
+		/* estimate the time of overhead (microsecs) */
 		Tcl_WideInt curOverhead = overhead * count;
 		if (middle > curOverhead) {
 		    middle -= curOverhead;
@@ -4291,7 +4292,7 @@ usage:
 		measureOverhead = (double)middle / count;
 	    }
 	    objs[0] = Tcl_NewDoubleObj(measureOverhead);
-	    TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#-overhead,"); /* mics */
+	    TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#-overhead"); /* mics */
 	    objs += 2;
 	}
 
@@ -4325,15 +4326,21 @@ usage:
 	    objs[4] = Tcl_NewWideIntObj((count / middle) * 1000000);
 	}
 
+	/* estimated net execution time (in millisecs) */
+	if (!calibrate) {
+	    objs[6] = Tcl_ObjPrintf("%.3f", (double)middle / 1000);
+	    TclNewLiteralStringObj(objs[7], "nett-ms");
+	}
+
 	/*
 	* Construct the result as a list because many programs have always parsed
 	* as such (extracting the first element, typically).
 	*/
 
-	TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#,"); /* mics/# */
-	TclNewLiteralStringObj(objs[3], "#,");
+	TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#"); /* mics/# */
+	TclNewLiteralStringObj(objs[3], "#");
 	TclNewLiteralStringObj(objs[5], "#/sec");
-	Tcl_SetObjResult(interp, Tcl_NewListObj((!calibrate) ? 6 : 8, objarr));
+	Tcl_SetObjResult(interp, Tcl_NewListObj(8, objarr));
     }
 
 done:

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4051,11 +4051,15 @@ Tcl_TimeRateObjCmd(
     int objc,			/* Number of arguments. */
     Tcl_Obj *const objv[])	/* Argument objects. */
 {
-    static double measureOverhead = 0;
+    static 
+    double measureOverhead = 0; /* global measure-overhead */
+    double overhead = -1;       /* given measure-overhead */
     register Tcl_Obj *objPtr;
-    register int result;
+    register int result, i;
+    Tcl_Obj *calibrate = NULL, *direct = NULL;
     Tcl_WideInt count = 0;      /* Holds repetition count */
-    Tcl_WideInt maxms;          /* Maximal running time (in milliseconds) */
+    Tcl_WideInt maxms = -0x7FFFFFFFFFFFFFFFL; 
+				/* Maximal running time (in milliseconds) */
     Tcl_WideInt threshold = 1;  /* Current threshold for check time (faster
                                  * repeat count without time check) */
     Tcl_WideInt maxIterTm = 1;  /* Max time of some iteration as max threshold
@@ -4065,82 +4069,149 @@ Tcl_TimeRateObjCmd(
     Tcl_Time now;
 #endif
 
-    NRE_callback *rootPtr;
-    ByteCode     *codePtr;
+    static const char *const options[] = {
+	"-direct",	"-overhead",	"-calibrate",	"--",	NULL
+    };
+    enum options {
+	TMRT_EV_DIRECT,	TMRT_OVERHEAD,	TMRT_CALIBRATE,	TMRT_LAST
+    };
 
-    if (objc == 2) {
-	maxms = 1000;
-    } else if (objc == 3) {
-	result = TclGetWideIntFromObj(interp, objv[2], &maxms);
+    NRE_callback *rootPtr;
+    ByteCode     *codePtr = NULL;
+
+    for (i = 1; i < objc - 1; i++) {
+    	int index;
+	if (Tcl_GetIndexFromObj(NULL, objv[i], options, "option", TCL_EXACT,
+		&index) != TCL_OK) {
+	    break;
+	}
+	if (index == TMRT_LAST) {
+	    i++;
+	    break;
+	}
+	switch ((enum options) index) {
+	case TMRT_EV_DIRECT:
+	    direct = objv[i];
+	    break;
+	case TMRT_OVERHEAD:
+	    if (++i >= objc - 1) {
+		goto usage;
+	    }
+	    if (Tcl_GetDoubleFromObj(interp, objv[i], &overhead) != TCL_OK) {
+		return TCL_ERROR;
+	    }
+	    break;
+	case TMRT_CALIBRATE:
+	    calibrate = objv[i];
+	    break;
+	}
+    }
+
+    if (i >= objc || i < objc-2) {
+usage:
+	Tcl_WrongNumArgs(interp, 1, objv, "?-direct? ?-calibrate? ?-overhead double? command ?time?");
+	return TCL_ERROR;
+    }
+    objPtr = objv[i++];
+    if (i < objc) {
+	result = TclGetWideIntFromObj(interp, objv[i], &maxms);
 	if (result != TCL_OK) {
 	    return result;
 	}
-    } else {
-	Tcl_WrongNumArgs(interp, 1, objv, "command ?time?");
-	return TCL_ERROR;
     }
 
-    objPtr = objv[1];
+    /* if calibrate */
+    if (calibrate) {
 
-    /* if no command */
-    if (!*TclGetString(objPtr) && !objPtr->length) {
-	/* if calibration needed */
-	if (objc == 2 || maxms >= 10000) {
-	    Tcl_Obj *clobjv[3];
+	/* if no time specified for the calibration */
+	if (maxms == -0x7FFFFFFFFFFFFFFFL) {
+	    Tcl_Obj *clobjv[6];
+	    Tcl_WideInt maxCalTime = 5000;
+	    double lastMeasureOverhead = measureOverhead;
 	    
-	    /* reset last measurement overhead */
-	    measureOverhead = 0;
+	    clobjv[0] = objv[0]; 
+	    i = 1;
+	    if (direct) {
+	    	clobjv[i++] = direct;
+	    }
+	    clobjv[i++] = objPtr; 
 
-	    clobjv[0] = objv[0]; clobjv[1] = objv[1]; 
+	    /* reset last measurement overhead */
+	    measureOverhead = (double)0;
 
 	    /* self-call with 100 milliseconds to warm-up,
 	     * before entering the calibration cycle */
-	    TclNewLongObj(clobjv[2], 100);
-	    Tcl_IncrRefCount(clobjv[2]);
-	    Tcl_TimeRateObjCmd(dummy, interp, 3, clobjv);    
-	    Tcl_DecrRefCount(clobjv[2]);
-
-	    /* set last measurement overhead to max */
-	    measureOverhead = (double)0X7FFFFFFF;
-
-	    if (objc == 2) {
-	    	Tcl_WideInt maxCalTime = 11000;
-	    	double lastMeasureOverhead;
-		/* calibration cycle until it'll be preciser */
-		maxms = 1000;
-		do {
-		    lastMeasureOverhead = measureOverhead;
-		    TclNewLongObj(clobjv[2], (int)maxms);
-		    Tcl_IncrRefCount(clobjv[2]);
-		    result = Tcl_TimeRateObjCmd(dummy, interp, 3, clobjv);
-		    Tcl_DecrRefCount(clobjv[2]);
-		    maxCalTime -= maxms;
-		    /* increase maxms for preciser calibration */
-		    maxms += (maxms / 4);
-		} while (  measureOverhead < lastMeasureOverhead
-			&& (int)(measureOverhead * 10000) != 
-			   (int)(lastMeasureOverhead * 10000)
-			&& maxCalTime > 0
-		);
-
+	    TclNewLongObj(clobjv[i], 100);
+	    Tcl_IncrRefCount(clobjv[i]);
+	    result = Tcl_TimeRateObjCmd(dummy, interp, i+1, clobjv);
+	    Tcl_DecrRefCount(clobjv[i]);
+	    if (result != TCL_OK) {
 		return result;
 	    }
+
+	    i--;
+	    clobjv[i++] = calibrate;
+	    clobjv[i++] = objPtr; 
+
+	    /* set last measurement overhead to max */
+	    measureOverhead = (double)0x7FFFFFFFFFFFFFFFL;
+
+	    /* calibration cycle until it'll be preciser */
+	    maxms = -1000;
+	    do {
+		lastMeasureOverhead = measureOverhead;
+		TclNewLongObj(clobjv[i], (int)maxms);
+		Tcl_IncrRefCount(clobjv[i]);
+		result = Tcl_TimeRateObjCmd(dummy, interp, i+1, clobjv);
+		Tcl_DecrRefCount(clobjv[i]);
+		if (result != TCL_OK) {
+		    return result;
+		}
+		maxCalTime += maxms;
+		/* increase maxms for preciser calibration */
+		maxms -= (-maxms / 4);
+		/* as long as new value more as 0.05% better */
+	    } while ( (measureOverhead >= lastMeasureOverhead
+		    || measureOverhead / lastMeasureOverhead <= 0.9995)
+		    && maxCalTime > 0
+	    );
+
+	    return result;
 	}
-	else
 	if (maxms == 0) {
 	    /* reset last measurement overhead */
 	    measureOverhead = 0;
+	    Tcl_SetObjResult(interp, Tcl_NewLongObj(0));
+	    return TCL_OK;
 	}
+
+	/* if time is negative - make current overhead more precise */
+	if (maxms > 0) {
+	    /* set last measurement overhead to max */
+	    measureOverhead = (double)0x7FFFFFFFFFFFFFFFL;
+	} else {
+	    maxms = -maxms;
+	}
+
+    }
+
+    if (maxms == -0x7FFFFFFFFFFFFFFFL) {
+    	maxms = 1000;
+    }
+    if (overhead == -1) {
+	overhead = measureOverhead;
     }
 
     /* be sure that resetting of result will not smudge the further measurement */
     Tcl_ResetResult(interp);
 
     /* compile object */
-    if (TclInterpReady(interp) != TCL_OK) {
-	return TCL_ERROR;
+    if (!direct) {
+	if (TclInterpReady(interp) != TCL_OK) {
+	    return TCL_ERROR;
+	}
+	codePtr = TclCompileObj(interp, objPtr, NULL, 0);
     }
-    codePtr = TclCompileObj(interp, objPtr, NULL, 0);
 
     /* get start and stop time */
 #ifndef TCL_WIDE_CLICKS
@@ -4157,9 +4228,15 @@ Tcl_TimeRateObjCmd(
     	/* eval single iteration */
     	count++;
 
-	rootPtr = TOP_CB(interp);
-	result = TclNRExecuteByteCode(interp, codePtr);
-	result = TclNRRunCallbacks(interp, result, rootPtr);
+	if (!direct) {
+	    /* precompiled */
+	    rootPtr = TOP_CB(interp);
+	    result = TclNRExecuteByteCode(interp, codePtr);
+	    result = TclNRRunCallbacks(interp, result, rootPtr);
+	} else {
+	    /* eval */
+	    result = TclEvalObjEx(interp, objPtr, 0, NULL, 0);
+	}
 	if (result != TCL_OK) {
 	    return result;
 	}
@@ -4189,19 +4266,18 @@ Tcl_TimeRateObjCmd(
 	}
     }
 
-    if (1) {
-	Tcl_Obj *objs[8];
+    {
+	Tcl_Obj *objarr[8], **objs = objarr;
 	Tcl_WideInt val;
 	const char *fmt;
 
-	objs[6] = NULL;
 	middle -= start;                     /* execution time in microsecs */
 
 	/* if not calibrate */
-	if (maxms < 1000 || *TclGetString(objPtr) || objPtr->length) {
+	if (!calibrate) {
 	    /* minimize influence of measurement overhead */
-	    if (measureOverhead > 0) {
-		Tcl_WideInt curOverhead = measureOverhead * count;
+	    if (overhead > 0) {
+		Tcl_WideInt curOverhead = overhead * count;
 		if (middle > curOverhead) {
 		    middle -= curOverhead;
 		} else {
@@ -4213,8 +4289,9 @@ Tcl_TimeRateObjCmd(
 	    if (measureOverhead > (double)middle / count) {
 		measureOverhead = (double)middle / count;
 	    }
-	    objs[6] = Tcl_NewDoubleObj(measureOverhead);
-	    TclNewLiteralStringObj(objs[7], "\xC2\xB5s/#-overhead"); /* mics */
+	    objs[0] = Tcl_NewDoubleObj(measureOverhead);
+	    TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#-overhead,"); /* mics */
+	    objs += 2;
 	}
 
 	val = middle / count;                /* microsecs per iteration */
@@ -4233,7 +4310,7 @@ Tcl_TimeRateObjCmd(
 	
 	/* calculate speed as rate (count) per sec */
 	if (!middle) middle++; /* +1 ms, just to avoid divide by zero */
-	if (count < (0X7FFFFFFFFFFFFFFFL / 1000000)) {
+	if (count < (0x7FFFFFFFFFFFFFFFL / 1000000)) {
 	    val = (count * 1000000) / middle;
 	    if (val < 100000) {
 		if (val < 100)  { fmt = "%.3f"; } else
@@ -4255,7 +4332,7 @@ Tcl_TimeRateObjCmd(
 	TclNewLiteralStringObj(objs[1], "\xC2\xB5s/#,"); /* mics/# */
 	TclNewLiteralStringObj(objs[3], "#,");
 	TclNewLiteralStringObj(objs[5], "#/sec");
-	Tcl_SetObjResult(interp, Tcl_NewListObj((!objs[6]) ? 6 : 8, objs));
+	Tcl_SetObjResult(interp, Tcl_NewListObj((!calibrate) ? 6 : 8, objarr));
     }
 
     return result;

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4061,9 +4061,9 @@ Tcl_TimeRateObjCmd(
     Tcl_WideInt maxms = -0x7FFFFFFFFFFFFFFFL; 
 				/* Maximal running time (in milliseconds) */
     Tcl_WideInt threshold = 1;  /* Current threshold for check time (faster
-                                 * repeat count without time check) */
+				 * repeat count without time check) */
     Tcl_WideInt maxIterTm = 1;  /* Max time of some iteration as max threshold
-                                 * additionally avoid divide to zero (never < 1) */
+				 * additionally avoid divide to zero (never < 1) */
     register Tcl_WideInt start, middle, stop;
 #ifndef TCL_WIDE_CLICKS
     Tcl_Time now;
@@ -4302,7 +4302,7 @@ usage:
 	    if (val < 100)   { fmt = "%.4f"; } else
 	    if (val < 1000)  { fmt = "%.3f"; } else
 	    if (val < 10000) { fmt = "%.2f"; } else
-	                     { fmt = "%.1f"; };
+			     { fmt = "%.1f"; };
 	    objs[0] = Tcl_ObjPrintf(fmt, ((double)middle)/count);
 	}
 
@@ -4315,7 +4315,7 @@ usage:
 	    if (val < 100000) {
 		if (val < 100)  { fmt = "%.3f"; } else
 		if (val < 1000) { fmt = "%.2f"; } else
-		                { fmt = "%.1f"; };
+				{ fmt = "%.1f"; };
 		objs[4] = Tcl_ObjPrintf(fmt, ((double)(count * 1000000)) / middle);
 	    } else {
 		objs[4] = Tcl_NewWideIntObj(val);

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4111,8 +4111,8 @@ Tcl_TimeRateObjCmd(
 	}
 	/* as relation between remaining time and time since last check */
 	threshold = ((stop - middle) / maxIterTm) / 4; 
-	if (threshold > 50000) {           /* fix for too large threshold */
-	    threshold = 50000;
+	if (threshold > 5000) {           /* fix for too large threshold */
+	    threshold = 5000;
 	}
     }
 

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4093,9 +4093,9 @@ Tcl_TimeRateObjCmd(
 
 	    clobjv[0] = objv[0]; clobjv[1] = objv[1]; 
 
-	    /* self-call with 250 milliseconds to warm-up,
+	    /* self-call with 100 milliseconds to warm-up,
 	     * before entering the calibration cycle */
-	    TclNewLongObj(clobjv[2], 250);
+	    TclNewLongObj(clobjv[2], 100);
 	    Tcl_IncrRefCount(clobjv[2]);
 	    Tcl_TimeRateObjCmd(dummy, interp, 3, clobjv);    
 	    Tcl_DecrRefCount(clobjv[2]);
@@ -4117,7 +4117,11 @@ Tcl_TimeRateObjCmd(
 		    maxCalTime -= maxms;
 		    /* increase maxms for preciser calibration */
 		    maxms += (maxms / 4);
-		} while (measureOverhead < lastMeasureOverhead && maxCalTime > 0);
+		} while (  measureOverhead < lastMeasureOverhead
+			&& (int)(measureOverhead * 10000) != 
+			   (int)(lastMeasureOverhead * 10000)
+			&& maxCalTime > 0
+		);
 
 		return result;
 	    }
@@ -4179,9 +4183,9 @@ Tcl_TimeRateObjCmd(
 	    maxIterTm = threshold;
 	}
 	/* as relation between remaining time and time since last check */
-	threshold = ((stop - middle) / maxIterTm) / 2;
-	if (threshold > 10000) {           /* fix for too large threshold */
-	    threshold = 10000;
+	threshold = ((stop - middle) / maxIterTm) / 4;
+	if (threshold > 100000) {           /* fix for too large threshold */
+	    threshold = 100000;
 	}
     }
 

--- a/generic/tclCmdMZ.c
+++ b/generic/tclCmdMZ.c
@@ -4058,7 +4058,7 @@ Tcl_TimeRateObjCmd(
                                  * repeat count without time check) */
     Tcl_WideInt maxIterTm = 1;  /* Max time of some iteration as max threshold
                                  * additionally avoid divide to zero (never < 1) */
-    Tcl_WideInt start, middle, stop;
+    register Tcl_WideInt start, middle, stop;
 #ifndef TCL_WIDE_CLICKS
     Tcl_Time now;
 #endif
@@ -4078,7 +4078,7 @@ Tcl_TimeRateObjCmd(
     objPtr = objv[1];
 #ifndef TCL_WIDE_CLICKS
     Tcl_GetTime(&now);
-    start = now.sec * 1000000 + now.usec;
+    start = now.sec; start *= 1000000; start += now.usec;
 #else
     start = TclpGetWideClicks();
 #endif
@@ -4095,22 +4095,22 @@ Tcl_TimeRateObjCmd(
 	if (--threshold > 0) continue;
 
 	/* check stop time reached, estimate new threshold */
-	threshold = middle;
     #ifndef TCL_WIDE_CLICKS
 	Tcl_GetTime(&now);
-	middle = now.sec * 1000000 + now.usec;
+	middle = now.sec; middle *= 1000000; middle += now.usec;
     #else
 	middle = TclpGetWideClicks();
     #endif
 	if (middle >= stop) {
 	    break;
 	}
-	threshold = (middle - threshold);  /* time since last check in microsecs */
+	/* average iteration time in microsecs */
+	threshold = (middle - start) / count;
 	if (threshold > maxIterTm) {
 	    maxIterTm = threshold;
 	}
 	/* as relation between remaining time and time since last check */
-	threshold = ((stop - middle) / maxIterTm) / 4; 
+	threshold = ((stop - middle) / maxIterTm) / 2;
 	if (threshold > 5000) {           /* fix for too large threshold */
 	    threshold = 5000;
 	}

--- a/generic/tclInt.h
+++ b/generic/tclInt.h
@@ -3456,6 +3456,9 @@ MODULE_SCOPE int	Tcl_ThrowObjCmd(ClientData dummy, Tcl_Interp *interp,
 MODULE_SCOPE int	Tcl_TimeObjCmd(ClientData clientData,
 			    Tcl_Interp *interp, int objc,
 			    Tcl_Obj *const objv[]);
+MODULE_SCOPE int	Tcl_TimeRateObjCmd(ClientData clientData,
+			    Tcl_Interp *interp, int objc,
+			    Tcl_Obj *const objv[]);
 MODULE_SCOPE int	Tcl_TraceObjCmd(ClientData clientData,
 			    Tcl_Interp *interp, int objc,
 			    Tcl_Obj *const objv[]);

--- a/library/reg/pkgIndex.tcl
+++ b/library/reg/pkgIndex.tcl
@@ -1,9 +1,19 @@
 if {([info commands ::tcl::pkgconfig] eq "")
 	|| ([info sharedlibextension] ne ".dll")} return
 if {[::tcl::pkgconfig get debug]} {
+  if {[info exists [file join $dir tclreg13g.dll]]} {
     package ifneeded registry 1.3.2 \
             [list load [file join $dir tclreg13g.dll] registry]
+  } else {
+    package ifneeded registry 1.3.2 \
+            [list load tclreg13g registry]
+  }
 } else {
+  if {[info exists [file join $dir tclreg13.dll]]} {
     package ifneeded registry 1.3.2 \
             [list load [file join $dir tclreg13.dll] registry]
+  } else {
+    package ifneeded registry 1.3.2 \
+            [list load tclreg13 registry]
+  }
 }

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -37009,10 +37009,10 @@ test clock-67.5 {Change scan %x output on global locale change [Bug 4a0c163d24]}
     set current [msgcat::mclocale]
 } -body {
     msgcat::mclocale de_de
-    set res [clock scan "01.01.1970" -locale current -format %x]
+    set res [clock scan "01.01.1970" -locale current -format %x -gmt 1]
     msgcat::mclocale en_uk
     # This will fail without the bug fix, as still de_de is active
-    expr {$res == [clock scan "01/01/1970" -locale current -format %x]}
+    expr {$res == [clock scan "01/01/1970" -locale current -format %x -gmt 1]}
 } -cleanup {
     msgcat::mclocale $current
 } -result {1}

--- a/unix/tclUnixTime.c
+++ b/unix/tclUnixTime.c
@@ -158,7 +158,7 @@ TclpGetWideClicks(void)
 	Tcl_Time time;
 
 	tclGetTimeProcPtr(&time, tclTimeClientData);
-	now = (Tcl_WideInt) (time.sec*1000000 + time.usec);
+	now = ((Tcl_WideInt)time.sec)*1000000 + time.usec;
     } else {
 #ifdef MAC_OSX_TCL
 	now = (Tcl_WideInt) (mach_absolute_time() & INT64_MAX);

--- a/win/tclWinTime.c
+++ b/win/tclWinTime.c
@@ -280,10 +280,6 @@ NativeGetTime(
     Tcl_Time *timePtr,
     ClientData clientData)
 {
-    struct _timeb t;
-    int useFtime = 1;		/* Flag == TRUE if we need to fall back on
-				 * ftime rather than using the perf counter. */
-
     /*
      * Initialize static storage on the first trip through.
      *
@@ -398,6 +394,10 @@ NativeGetTime(
 	 * time.
 	 */
 
+	ULARGE_INTEGER fileTimeLastCall;
+	LARGE_INTEGER perfCounterLastCall, curCounterFreq;
+				/* Copy with current data of calibration cycle */
+
 	LARGE_INTEGER curCounter;
 				/* Current performance counter. */
 	Tcl_WideInt curFileTime;/* Current estimated time, expressed as 100-ns
@@ -411,9 +411,29 @@ NativeGetTime(
 	posixEpoch.LowPart = 0xD53E8000;
 	posixEpoch.HighPart = 0x019DB1DE;
 
+	QueryPerformanceCounter(&curCounter);
+
+	/* 
+	 * Hold time section locked as short as possible
+	 */
 	EnterCriticalSection(&timeInfo.cs);
 
-	QueryPerformanceCounter(&curCounter);
+	fileTimeLastCall.QuadPart = timeInfo.fileTimeLastCall.QuadPart;
+	perfCounterLastCall.QuadPart = timeInfo.perfCounterLastCall.QuadPart;
+	curCounterFreq.QuadPart = timeInfo.curCounterFreq.QuadPart;
+
+	LeaveCriticalSection(&timeInfo.cs);
+
+	/*
+	 * If calibration cycle occurred after we get curCounter
+	 */
+	if (curCounter.QuadPart <= perfCounterLastCall.QuadPart) {
+	    usecSincePosixEpoch = 
+		(fileTimeLastCall.QuadPart - posixEpoch.QuadPart) / 10;
+	    timePtr->sec = (long) (usecSincePosixEpoch / 1000000);
+	    timePtr->usec = (unsigned long) (usecSincePosixEpoch % 1000000);
+	    return;
+	}
 
 	/*
 	 * If it appears to be more than 1.1 seconds since the last trip
@@ -425,31 +445,31 @@ NativeGetTime(
 	 * loop should recover.
 	 */
 
-	if (curCounter.QuadPart - timeInfo.perfCounterLastCall.QuadPart <
-		11 * timeInfo.curCounterFreq.QuadPart / 10) {
-	    curFileTime = timeInfo.fileTimeLastCall.QuadPart +
-		 ((curCounter.QuadPart - timeInfo.perfCounterLastCall.QuadPart)
-		    * 10000000 / timeInfo.curCounterFreq.QuadPart);
-	    timeInfo.fileTimeLastCall.QuadPart = curFileTime;
-	    timeInfo.perfCounterLastCall.QuadPart = curCounter.QuadPart;
+	if (curCounter.QuadPart - perfCounterLastCall.QuadPart <
+		11 * curCounterFreq.QuadPart / 10
+	) {
+	    curFileTime = fileTimeLastCall.QuadPart +
+		 ((curCounter.QuadPart - perfCounterLastCall.QuadPart)
+		    * 10000000 / curCounterFreq.QuadPart);
+
 	    usecSincePosixEpoch = (curFileTime - posixEpoch.QuadPart) / 10;
 	    timePtr->sec = (long) (usecSincePosixEpoch / 1000000);
 	    timePtr->usec = (unsigned long) (usecSincePosixEpoch % 1000000);
-	    useFtime = 0;
+	    return;
 	}
-
-	LeaveCriticalSection(&timeInfo.cs);
     }
 
-    if (useFtime) {
+    do {
 	/*
 	 * High resolution timer is not available. Just use ftime.
 	 */
+	struct _timeb t;
 
 	_ftime(&t);
 	timePtr->sec = (long)t.time;
 	timePtr->usec = t.millitm * 1000;
-    }
+
+    } while(0);
 }
 
 /*


### PR DESCRIPTION
This is a interim PR back-porting some features from my tclSE engine.
Currently used as merge-point to #2 to compare performance between original tcl-clock and new tcl-clock engines.

<h4>Contains:</h4>

- new command `timerate`, that allows to do the measurement of code executing more precise and in opposition to command `time` is time-related (not count-related);
- time-drifts bug fix, corresponds http://core.tcl.tk/tcl/info/b6fc234ef3dac6df (see ticket http://core.tcl.tk/tcl/tktview/b87ad7e9146832d505f9a430d779c5313c440256)
- several small fixes to test tcl-clock under Windows (timezone, registry in development env, etc.);

<h4>Additionally pros of command "timerate"</h4>

- `timerate` can be calibrated to minimize influence of measurement overhead (and byte code execution overhead) - `timerate -calibrate {}`. <br/>Following example diff shows influence of measurement and execution overheads (the times retrieved for execution of empty scope-block resp. of each `set i ...` is more precise after calibration), e. g. in reality the execution time of `set i ...` amounts to ca. 0.057 µs/#:
```diff
+ % # calibrate to minimize influence of overhead:
+ % timerate -calibrate {}
+ 0.04763798110968011 µs/#-overhead, 0.048467 µs/#, 40275119 #, 20632745 #/sec
  % timerate {}
- 0.049425 µs/#, 20232613 #, 20232613 #/sec
+ 0.003276 µs/#, 19640807 #, 305208960 #/sec
  % timerate {set i 0} 5000
- 0.155394 µs/#, 32176202 #, 6435240 #/sec
+ 0.057090 µs/#, 47953979 #, 17516238 #/sec
  % timerate {set i 0; set i 1} 5000
- 0.221634 µs/#, 22559694 #, 4511938 #/sec
+ 0.113668 µs/#, 31042572 #, 8797543 #/sec
  % timerate {set i 0; set i 1; set i 2} 5000
- 0.293191 µs/#, 17053736 #, 3410747 #/sec
+ 0.190558 µs/#, 21012023 #, 5247746 #/sec
```
- to reset previously calibrated overhead `timerate -calibrate {} 0` can be used;
- it can measure compiled and not compiled code pieces (use option `-direct` to disable "compilation" outside of measure cycle, and will be executed by `TclEvalObjEx` instead `TclNRExecuteByteCode`);
Normally it uses compiled version to measure (as it would be a part of compiled script or procedure body):
```diff
- # measure not-compiled version:
- % timerate -direct {}
- 0.089162 µs/#, 11215515 #, 11215515 #/sec
+ # measure compiled version:
+ % timerate {}
+ 0.049425 µs/#, 20232613 #, 20232613 #/sec
```
- with option `-overhead` an external calculated overhead can be specified for the `timerate` command to measure execution of the part of script. Following example shows possibility to ignore overhead of execution of `_init` procedure resp. more precise the speed of part `string tolower ...` only:
```
% proc _init {} { string trim " test " }
% timerate { set obj [_init]; string tolower $obj }
0.758217 µs/#, 1318883 #, 1318883 #/sec
% timerate \
   -overhead [lindex [timerate { set obj [_init] }] 0] \
           { set obj [_init]; string tolower $obj }
0.097757 µs/#, 1393420 #, 10229413 #/sec
```
